### PR TITLE
Add additional argument, "qq.colour" 

### DIFF
--- a/R/geom_qqboxplot.R
+++ b/R/geom_qqboxplot.R
@@ -63,10 +63,12 @@ geom_qqboxplot <- function(mapping = NULL, data = NULL,
                            notch = FALSE,
                            notchwidth = 0.5,
                            varwidth = FALSE,
+                           qq.colour = NULL,
+                           qq.color = NULL,
                            na.rm = FALSE,
                            show.legend = NA,
                            inherit.aes = TRUE) {
-
+  
   # varwidth = TRUE is not compatible with preserve = "total"
   if (is.character(position)) {
     if (varwidth == TRUE) position <- ggplot2::position_dodge2(preserve = "single")
@@ -76,7 +78,7 @@ geom_qqboxplot <- function(mapping = NULL, data = NULL,
       position$preserve <- "single"
     }
   }
-
+  
   ggplot2::layer(
     data = data,
     mapping = mapping,
@@ -95,6 +97,7 @@ geom_qqboxplot <- function(mapping = NULL, data = NULL,
       notch = notch,
       notchwidth = notchwidth,
       varwidth = varwidth,
+      qq.colour = qq.color %||% qq.colour,
       na.rm = na.rm,
       ...
     )
@@ -103,160 +106,164 @@ geom_qqboxplot <- function(mapping = NULL, data = NULL,
 
 
 GeomQqboxplot <- ggplot2::ggproto("GeomQqboxplot", ggplot2::Geom,
-
-                         # need to declare `width`` here in case this geom is used with a stat that
-                         # doesn't have a `width` parameter (e.g., `stat_identity`).
-                         extra_params = c("na.rm", "width"),
-
-                         setup_data = function(data, params) {
-                           data$width <- data$width %||%
-                             params$width %||% (resolution(data$x, FALSE) * 0.9)
-
-                           if (!is.null(data$outliers)) {
-                             suppressWarnings({
-                               out_min <- vapply(data$outliers, min, numeric(1))
-                               out_max <- vapply(data$outliers, max, numeric(1))
-                             })
-
-                             data$ymin_final <- pmin(out_min, data$ymin)
-                             data$ymax_final <- pmax(out_max, data$ymax)
-                           }
-
-                           # if `varwidth` not requested or not available, don't use it
-                           if (is.null(params) || is.null(params$varwidth) || !params$varwidth || is.null(data$relvarwidth)) {
-                             data$xmin <- data$x - data$width / 2
-                             data$xmax <- data$x + data$width / 2
-                           } else {
-                             # make `relvarwidth` relative to the size of the largest group
-                             data$relvarwidth <- data$relvarwidth / max(data$relvarwidth)
-                             data$xmin <- data$x - data$relvarwidth * data$width / 2
-                             data$xmax <- data$x + data$relvarwidth * data$width / 2
-                           }
-                           data$width <- NULL
-                           if (!is.null(data$relvarwidth)) data$relvarwidth <- NULL
-
-                           data
-                         },
-
-                         draw_group = function(data, panel_params, coord, fatten = 2,
-                                               outlier.colour = NULL, outlier.fill = NULL,
-                                               outlier.shape = 19,
-                                               outlier.size = 1.5, outlier.stroke = 0.5,
-                                               outlier.alpha = NULL,
-                                               notch = FALSE, notchwidth = 0.5, varwidth = FALSE) {
-
-                           common <- base::data.frame(
-                             colour = data$colour,
-                             size = data$size,
-                             linetype = data$linetype,
-                             fill = scales::alpha(data$fill, data$alpha),
-                             group = data$group,
-                             stringsAsFactors = FALSE
-                           )
-
-
-                           whiskers <- base::data.frame(
-                             x = as.integer(data$x)+c(data$deviatlower[[1]], data$deviatupper[[1]]),
-                             y = c(data$lowery[[1]], data$uppery[[1]]),
-                             alpha = NA,
-                             common,
-                             stringsAsFactors = FALSE
-                           )
-
-                           whisker_upper_bound <- base::data.frame(
-                             x = c(as.integer(data$x)+data$upperlower[[1]], rev(as.integer(data$x)+data$upperupper[[1]])),
-                             y = c(data$uppery[[1]], rev(data$uppery[[1]])),
-                             alpha = .1,
-                             fill=scales::muted('red'),
-                             colour=NA,
-                             common,
-                             stringsAsFactors = FALSE
-                           )
-
-                           whisker_lower_bound <- base::data.frame(
-                             x = c(as.integer(data$x)+data$lowerlower[[1]], rev(as.integer(data$x)+data$lowerupper[[1]])),
-                             y = c(data$lowery[[1]], rev(data$lowery[[1]])),
-                             alpha = .1,
-                             fill=scales::muted('red'),
-                             colour=NA,
-                             common,
-                             stringsAsFactors = FALSE
-                           )
-
-                           whisker_upper_bound_point <- base::data.frame(
-                             x = c(as.integer(data$x)+data$upperlower[[1]], rev(as.integer(data$x)+data$upperupper[[1]])),
-                             y = c(data$uppery[[1]], rev(data$uppery[[1]])),
-                             alpha = .15,
-                             fill=NA,
-                             colour=scales::muted('red'),
-                             size=.5,
-                             shape = outlier.shape %||% data$shape[1],
-                             stroke = outlier.stroke %||% data$stroke[1],
-                             stringsAsFactors = FALSE
-                           )
-
-                           whisker_lower_bound_point <- base::data.frame(
-                             x = c(as.integer(data$x)+data$lowerlower[[1]], rev(as.integer(data$x)+data$lowerupper[[1]])),
-                             y = c(data$lowery[[1]], rev(data$lowery[[1]])),
-                             alpha = .15,
-                             fill=NA,
-                             colour=scales::muted('red'),
-                             size=.5,
-                             shape = outlier.shape %||% data$shape[1],
-                             stroke = outlier.stroke %||% data$stroke[1],
-                             stringsAsFactors = FALSE
-                           )
-
-
-
-
-                           box <- base::data.frame(
-                             xmin = data$xmin,
-                             xmax = data$xmax,
-                             ymin = data$lower,
-                             y = data$middle,
-                             ymax = data$upper,
-                             ynotchlower = ifelse(notch, data$notchlower, NA),
-                             ynotchupper = ifelse(notch, data$notchupper, NA),
-                             notchwidth = notchwidth,
-                             alpha = data$alpha,
-                             common,
-                             stringsAsFactors = FALSE
-                           )
-
-                           if (!is.null(data$outliers) && length(data$outliers[[1]] >= 1)) {
-                             outliers <- base::data.frame(
-                               y = data$outliers[[1]],
-                               x = data$x[1],
-                               colour = outlier.colour %||% data$colour[1],
-                               fill = outlier.fill %||% data$fill[1],
-                               shape = outlier.shape %||% data$shape[1],
-                               size = outlier.size %||% data$size[1],
-                               stroke = outlier.stroke %||% data$stroke[1],
-                               fill = NA,
-                               alpha = outlier.alpha %||% data$alpha[1],
-                               stringsAsFactors = FALSE
-                             )
-                             outliers_grob <- ggplot2::GeomPoint$draw_panel(outliers, panel_params, coord)
-                           } else {
-                             outliers_grob <- NULL
-                           }
-
-                           ggname("geom_qqboxplot", grid::grobTree(
-                             outliers_grob,
-                             ggplot2::GeomPath$draw_panel(whiskers, panel_params, coord),
-                             ggplot2::GeomCrossbar$draw_panel(box, fatten = fatten, panel_params, coord),
-                             ggplot2::GeomPolygon$draw_panel(whisker_upper_bound, panel_params, coord),
-                             ggplot2::GeomPolygon$draw_panel(whisker_lower_bound, panel_params, coord),
-                             ggplot2::GeomPoint$draw_panel(whisker_upper_bound_point, panel_params, coord),
-                             ggplot2::GeomPoint$draw_panel(whisker_lower_bound_point, panel_params, coord)
-                           ))
-                         },
-
-                         draw_key = ggplot2::draw_key_boxplot,
-
-                         default_aes = ggplot2::aes(weight = 1, colour = "grey20", fill = "white", size = 0.5,
-                                           alpha = NA, shape = 19, linetype = "solid"),
-
-                         required_aes = c("x", "lower", "upper", "middle", "ymin", "ymax", "lowery")
+                                  
+                                  # need to declare `width`` here in case this geom is used with a stat that
+                                  # doesn't have a `width` parameter (e.g., `stat_identity`).
+                                  extra_params = c("na.rm", "width"),
+                                  
+                                  setup_data = function(data, params) {
+                                    data$width <- data$width %||%
+                                      params$width %||% (resolution(data$x, FALSE) * 0.9)
+                                    
+                                    if (!is.null(data$outliers)) {
+                                      suppressWarnings({
+                                        out_min <- vapply(data$outliers, min, numeric(1))
+                                        out_max <- vapply(data$outliers, max, numeric(1))
+                                      })
+                                      
+                                      data$ymin_final <- pmin(out_min, data$ymin)
+                                      data$ymax_final <- pmax(out_max, data$ymax)
+                                    }
+                                    
+                                    # if `varwidth` not requested or not available, don't use it
+                                    if (is.null(params) || is.null(params$varwidth) || !params$varwidth || is.null(data$relvarwidth)) {
+                                      data$xmin <- data$x - data$width / 2
+                                      data$xmax <- data$x + data$width / 2
+                                    } else {
+                                      # make `relvarwidth` relative to the size of the largest group
+                                      data$relvarwidth <- data$relvarwidth / max(data$relvarwidth)
+                                      data$xmin <- data$x - data$relvarwidth * data$width / 2
+                                      data$xmax <- data$x + data$relvarwidth * data$width / 2
+                                    }
+                                    data$width <- NULL
+                                    if (!is.null(data$relvarwidth)) data$relvarwidth <- NULL
+                                    
+                                    data
+                                  },
+                                  
+                                  draw_group = function(data, panel_params, coord, fatten = 2,
+                                                        outlier.colour = NULL, outlier.fill = NULL,
+                                                        outlier.shape = 19,
+                                                        outlier.size = 1.5, outlier.stroke = 0.5,
+                                                        outlier.alpha = NULL, qq.colour = "NULL",
+                                                        notch = FALSE, notchwidth = 0.5, varwidth = FALSE) {
+                                    
+                                    common <- base::data.frame(
+                                      colour = data$colour,
+                                      size = data$size,
+                                      linetype = data$linetype,
+                                      fill = scales::alpha(data$fill, data$alpha),
+                                      group = data$group,
+                                      stringsAsFactors = FALSE
+                                    )
+                                    
+                                    
+                                    whiskers <- base::data.frame(
+                                      x = as.integer(data$x)+c(data$deviatlower[[1]], data$deviatupper[[1]]),
+                                      y = c(data$lowery[[1]], data$uppery[[1]]),
+                                      alpha = NA,
+                                      common,
+                                      stringsAsFactors = FALSE
+                                    )
+                                    
+                                    whisker_upper_bound <- base::data.frame(
+                                      x = c(as.integer(data$x)+data$upperlower[[1]], rev(as.integer(data$x)+data$upperupper[[1]])),
+                                      y = c(data$uppery[[1]], rev(data$uppery[[1]])),
+                                      alpha = .1,
+                                      fill=qq.colour,
+                                      # fill="steelblue",#scales::muted('red')
+                                      colour=NA,
+                                      common,
+                                      stringsAsFactors = FALSE
+                                    )
+                                    
+                                    whisker_lower_bound <- base::data.frame(
+                                      x = c(as.integer(data$x)+data$lowerlower[[1]], rev(as.integer(data$x)+data$lowerupper[[1]])),
+                                      y = c(data$lowery[[1]], rev(data$lowery[[1]])),
+                                      alpha = .1,
+                                      fill=qq.colour,
+                                      # fill="steelblue",#scales::muted('red')
+                                      colour=NA,
+                                      common,
+                                      stringsAsFactors = FALSE
+                                    )
+                                    
+                                    whisker_upper_bound_point <- base::data.frame(
+                                      x = c(as.integer(data$x)+data$upperlower[[1]], rev(as.integer(data$x)+data$upperupper[[1]])),
+                                      y = c(data$uppery[[1]], rev(data$uppery[[1]])),
+                                      alpha = .15,
+                                      fill=NA,
+                                      colour=qq.colour,
+                                      # colour="steelblue",#scales::muted('red')
+                                      size=.5,
+                                      shape = outlier.shape %||% data$shape[1],
+                                      stroke = outlier.stroke %||% data$stroke[1],
+                                      stringsAsFactors = FALSE
+                                    )
+                                    
+                                    whisker_lower_bound_point <- base::data.frame(
+                                      x = c(as.integer(data$x)+data$lowerlower[[1]], rev(as.integer(data$x)+data$lowerupper[[1]])),
+                                      y = c(data$lowery[[1]], rev(data$lowery[[1]])),
+                                      alpha = .15,
+                                      fill=NA,
+                                      colour=qq.colour,
+                                      # colour="steelblue",#scales::muted('red')
+                                      size=.5,
+                                      shape = outlier.shape %||% data$shape[1],
+                                      stroke = outlier.stroke %||% data$stroke[1],
+                                      stringsAsFactors = FALSE
+                                    )
+                                    
+                                    
+                                    
+                                    
+                                    box <- base::data.frame(
+                                      xmin = data$xmin,
+                                      xmax = data$xmax,
+                                      ymin = data$lower,
+                                      y = data$middle,
+                                      ymax = data$upper,
+                                      ynotchlower = ifelse(notch, data$notchlower, NA),
+                                      ynotchupper = ifelse(notch, data$notchupper, NA),
+                                      notchwidth = notchwidth,
+                                      alpha = data$alpha,
+                                      common,
+                                      stringsAsFactors = FALSE
+                                    )
+                                    
+                                    if (!is.null(data$outliers) && length(data$outliers[[1]] >= 1)) {
+                                      outliers <- base::data.frame(
+                                        y = data$outliers[[1]],
+                                        x = data$x[1], 
+                                        colour = outlier.colour %||% data$colour[1],
+                                        fill = outlier.fill %||% data$fill[1],
+                                        shape = outlier.shape %||% data$shape[1],
+                                        size = outlier.size %||% data$size[1],
+                                        stroke = outlier.stroke %||% data$stroke[1],
+                                        fill = NA,
+                                        alpha = outlier.alpha %||% data$alpha[1],
+                                        stringsAsFactors = FALSE
+                                      )
+                                      outliers_grob <- ggplot2::GeomPoint$draw_panel(outliers, panel_params, coord)
+                                    } else {
+                                      outliers_grob <- NULL
+                                    }
+                                    
+                                    ggname("geom_qqboxplot", grid::grobTree(
+                                      outliers_grob,
+                                      ggplot2::GeomPath$draw_panel(whiskers, panel_params, coord),
+                                      ggplot2::GeomCrossbar$draw_panel(box, fatten = fatten, panel_params, coord),
+                                      ggplot2::GeomPolygon$draw_panel(whisker_upper_bound, panel_params, coord),
+                                      ggplot2::GeomPolygon$draw_panel(whisker_lower_bound, panel_params, coord),
+                                      ggplot2::GeomPoint$draw_panel(whisker_upper_bound_point, panel_params, coord),
+                                      ggplot2::GeomPoint$draw_panel(whisker_lower_bound_point, panel_params, coord)
+                                    ))
+                                  },
+                                  
+                                  draw_key = ggplot2::draw_key_boxplot,
+                                  
+                                  default_aes = ggplot2::aes(weight = 1, colour = "grey20", fill = "white", size = 0.5,
+                                                             alpha = NA, shape = 19, linetype = "solid"),
+                                  
+                                  required_aes = c("x", "lower", "upper", "middle", "ymin", "ymax", "lowery")
 )


### PR DESCRIPTION
Dear Dr. Rodu,

I've recently raised an [issue](https://github.com/jrodu/qqboxplot/issues/1) regarding on changing the colour for the QQplot bands.

I'v added an extra argument to `geom_qqboxplot()` where specifying `qq.colour` argument will result in the change in the colour for the QQplot bands.

Following from the [example](https://cran.r-project.org/web/packages/qqboxplot/vignettes/qqboxplot-basic-usage.html) you published, 
This simple line brings the changes.
`  geom_qqboxplot(notch=TRUE, varwidth = TRUE, reference_dist="norm", qq.colour = 'steelblue')`
![image](https://github.com/jrodu/qqboxplot/assets/37770895/d432f61c-2c2c-48ab-9fc1-1676fd0ea4d1)
or
`  geom_qqboxplot(notch=TRUE, varwidth = TRUE, reference_dist="norm", qq.colour = scales::muted('red'))`
![image](https://github.com/jrodu/qqboxplot/assets/37770895/a5c8d322-7e09-4af4-a41d-46c75afd0c24)

I hereby create a pull request and hope this added some value to the package!

Kind Regards,
Johnny Lee